### PR TITLE
Fix configuration include

### DIFF
--- a/Basic-Video-Chat/main.cpp
+++ b/Basic-Video-Chat/main.cpp
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <string>
 
-#include "config.h"
+#include "config-sample.h"
 #include "renderer.h"
 
 static std::atomic<bool> g_is_connected(false);

--- a/Configurable-TURN-Servers/main.cpp
+++ b/Configurable-TURN-Servers/main.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "config.h"
+#include "config-sample.h"
 #include "renderer.h"
 
 #define MAX_CHAR_ARRAY_LENGTH 256

--- a/Custom-Audio-Device/main.cpp
+++ b/Custom-Audio-Device/main.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "config.h"
+#include "config-sample.h"
 #include "otk_thread.h"
 #include "renderer.h"
 

--- a/Custom-Video-Capturer/main.cpp
+++ b/Custom-Video-Capturer/main.cpp
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "config.h"
+#include "config-sample.h"
 #include "otk_thread.h"
 #include "renderer.h"
 

--- a/Publisher-Only/main.cpp
+++ b/Publisher-Only/main.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "config.h"
+#include "config-sample.h"
 #include "renderer.h"
 
 static std::atomic<bool> g_is_connected(false);

--- a/Signaling/main.cpp
+++ b/Signaling/main.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "config.h"
+#include "config-sample.h"
 #include "renderer.h"
 
 static std::atomic<bool> g_is_connected(false);


### PR DESCRIPTION
#### What is this PR doing?
Fix configuration file name for the samples, from 
#include "config.h"
to
#include "config-sample.h"

#### How should this be manually tested?
Build the samples on a clean installation