### PR TITLE
OPENTOK-43202: Switch to packagecloud repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   - docker run --rm -v $(pwd):/samples opentok/debian_buster:1.0
 branches:
   only:
-  - master
+  - main

--- a/Basic-Video-Chat/README.md
+++ b/Basic-Video-Chat/README.md
@@ -28,25 +28,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.

--- a/Configurable-TURN-Servers/README.md
+++ b/Configurable-TURN-Servers/README.md
@@ -31,25 +31,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.

--- a/Custom-Audio-Device/README.md
+++ b/Custom-Audio-Device/README.md
@@ -29,25 +29,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.

--- a/Custom-Video-Capturer/README.md
+++ b/Custom-Video-Capturer/README.md
@@ -29,25 +29,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN apt-get update \
        ca-certificates \
        wget \
        gnupg \
+       curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb https://dl.bintray.com/tokbox/debian buster main" | tee -a /etc/apt/sources.list
-RUN wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add -
+RUN curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 
 RUN apt-get update \
   && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
+RUN curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | bash
 
 RUN apt-get update \
   && apt-get install -y \

--- a/RTSP-Stream-Video-Capturer/README.md
+++ b/RTSP-Stream-Video-Capturer/README.md
@@ -30,25 +30,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.

--- a/Signaling/README.md
+++ b/Signaling/README.md
@@ -25,25 +25,13 @@ the sample application, install it and these other dependencies:
 
 The OpenTok Linux SDK for x86_64 (adm64) architecture is available as a Debian
 package. For Debian we support Debian 9 (strech) and 10 (buster). We maintain
-our own Debian repository on Bintray. For Debian 10, follow these steps
+our own Debian repository on packagecloud. For Debian 10, follow these steps
 to install the packages from our repository.
 
-* Add a new entry to your `/etc/apt/sources.list` file.
+* Add packagecloud repository:
 
 ```bash
-echo "deb https://dl.bintray.com/tokbox/debian buster main" | sudo tee -a /etc/apt/sources.list
-```
-
-* Add Bintray's GPG Key.
-
-```bash
-wget -O- -q https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-```
-
-* Resynchronize the package index files from their sources.
-
-```bash
-sudo apt-get update
+curl -s https://packagecloud.io/install/repositories/tokbox/debian/script.deb.sh | sudo bash
 ```
 
 * Install the OpenTok Linux SDK packages.


### PR DESCRIPTION
#### What is this PR doing?
With the [sunsetting of bintray](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), we needed to migrate our debian packages to a different repository.  This PR updates scripts and documentation to reflect that.

#### How should this be manually tested?
Most of the README changes were tested under a different ticket: OPENTOK-43277.

For the `Dockerfile` changes, it's sufficient to confirm that it builds.  From the directory in which this repo was cloned: 
```
docker build -t opentok-linux -f Dockerfile .
```
