### PR TITLE
VIDCS-751: Removes references to deprecated versions

### DIFF
--- a/Background-Substractor-Video-Capturer/README.md
+++ b/Background-Substractor-Video-Capturer/README.md
@@ -23,8 +23,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bulleyes). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -46,8 +46,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 

--- a/Basic-Video-Chat/README.md
+++ b/Basic-Video-Chat/README.md
@@ -21,8 +21,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bullseye). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -44,8 +44,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 

--- a/Configurable-TURN-Servers/README.md
+++ b/Configurable-TURN-Servers/README.md
@@ -21,8 +21,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bulleyes). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -44,8 +44,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 

--- a/Custom-Audio-Device/README.md
+++ b/Custom-Audio-Device/README.md
@@ -22,8 +22,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bullseye). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -45,8 +45,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 

--- a/Custom-Video-Capturer/README.md
+++ b/Custom-Video-Capturer/README.md
@@ -22,8 +22,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bullseye). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -45,8 +45,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 

--- a/Signaling/README.md
+++ b/Signaling/README.md
@@ -18,8 +18,8 @@ OpenTok Linux SDK.
 #### On Debian-based Linuxes
 
 The OpenTok Linux SDK for x86_64 is available as a Debian
-package. For Debian we support Debian 9 (Strech) and 10 (Buster). We maintain
-our own Debian repository on packagecloud. For Debian 10, follow these steps
+package. For Debian we support Debian 11 (Bullseye). We maintain
+our own Debian repository on packagecloud. Follow these steps
 to install the packages from our repository.
 
 * Add packagecloud repository:
@@ -41,8 +41,8 @@ and extract it and set the `LIBOPENTOK_PATH` environment variable to point to th
 For example:
 
 ```bash
-wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.23.0
-tar xvf libopentok_linux_llvm_x86_64-2.23.0
+wget https://tokbox.com/downloads/libopentok_linux_llvm_x86_64-2.25.0
+tar xvf libopentok_linux_llvm_x86_64-2.25.0
 export LIBOPENTOK_PATH=<path_to_SDK>
 ```
 


### PR DESCRIPTION
#### What is this PR doing?
Removes references to debian 9 and 10, since only debian 11 is supported now

#### How should this be manually tested?
N/A, since these are just doc changes
