### PR TITLE
VIDCS-773: Use Debian 11 for linux samples CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: xenial
 os:
 - linux
 before_install:
-  - docker build -t opentok/debian_buster:1.0 -f Dockerfile .
+  - docker build -t opentok/debian_bullseye:1.0 -f Dockerfile .
 script:
-  - docker run --rm -v $(pwd):/samples opentok/debian_buster:1.0
+  - docker run --rm -v $(pwd):/samples opentok/debian_bullseye:1.0
 branches:
   only:
   - main

--- a/Background-Substractor-Video-Capturer/main.cpp
+++ b/Background-Substractor-Video-Capturer/main.cpp
@@ -272,9 +272,9 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   video_capturer->format = OTC_VIDEO_FRAME_FORMAT_YUV420P;
-  video_capturer->width = static_cast<int>(opencv_video_capture.get(CV_CAP_PROP_FRAME_WIDTH));
-  video_capturer->height = static_cast<int>(opencv_video_capture.get(CV_CAP_PROP_FRAME_HEIGHT));
-  video_capturer->fps = static_cast<int>(opencv_video_capture.get(CV_CAP_PROP_FRAME_WIDTH));
+  video_capturer->width = static_cast<int>(opencv_video_capture.get(cv::CAP_PROP_FRAME_WIDTH));
+  video_capturer->height = static_cast<int>(opencv_video_capture.get(cv::CAP_PROP_FRAME_HEIGHT));
+  video_capturer->fps = static_cast<int>(opencv_video_capture.get(cv::CAP_PROP_FRAME_WIDTH));
   opencv_video_capture.release();
 
   RendererManager renderer_manager;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:buster
+FROM debian:bullseye
 
-RUN echo "deb http://security.debian.org/ buster/updates main" | tee -a /etc/apt/sources.list
+RUN echo "deb http://security.debian.org/ bullseye-security main" | tee -a /etc/apt/sources.list
 
 RUN apt-get update \
     && apt-get -yqqf --no-install-recommends install \


### PR DESCRIPTION
#### What is this PR doing?
Updates linux samples CI to use Debian bullseye. Minor changes to one of the samples app due to opencv new version.

#### How should this be manually tested?
CI passing.